### PR TITLE
fix: invisible header text

### DIFF
--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -294,6 +294,11 @@ $lvl3: if($isDark, $base, $crust);
   color: $lvl1;
 }
 
+// error message headers weirdly don't seem to be using --color-error-text
+.ui.negative.message .header {
+  color: var(--color-error-text)
+}
+
 // most recent commit hover when signed
 .ui.sha.isSigned.isVerified {
   .shortsha {


### PR DESCRIPTION
Should be readable now, unsure if it's an error upstream but it was using `--color-red` so I updated it to be `--color-error-text`:

![image](https://github.com/user-attachments/assets/3c4b8dcf-0f88-4590-b2e7-b25b6b179ef0)

Closes #17 