### PR TITLE
fix: unreadable repository topics edit button

### DIFF
--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -325,6 +325,11 @@ $lvl3: if($isDark, $base, $crust);
   color: var(--color-label-text) !important;
 }
 
+// repository topics edit button
+#manage_topic {
+  color: var(--color-text-light-2) !important;
+}
+
 // admonitions are using *-text variables for border/text colour
 // can't change values of the *-text variables without breaking readability on accented backgrounds
 blockquote {


### PR DESCRIPTION
since catppuccin uses a dark color for `#repo-topics` (upstream is light),
the `Manage topics` button is barely visible and requires its own rule

| before | after |
|-|-|
| <img width="156" height="34" alt="image" src="https://github.com/user-attachments/assets/1607b3fa-ce84-4126-a47e-b1ded11569ae" /> | <img width="156" height="34" alt="image" src="https://github.com/user-attachments/assets/f5a644bc-53be-4cfa-821f-35c075bebd7e" /> |
| <img width="156" height="34" alt="image" src="https://github.com/user-attachments/assets/15f716cd-96b8-45d6-86bb-02618132a0eb" /> | <img width="156" height="34" alt="image" src="https://github.com/user-attachments/assets/2e24ba90-8e6e-4b6c-9b43-b49d4ed82872" /> |



ref #60
ref #61
cc @sgoudham
