### PR TITLE
Adapt theme to be closer to default "Forgejo Dark" theme

### DIFF
--- a/src/_chroma.scss
+++ b/src/_chroma.scss
@@ -294,3 +294,7 @@
 .chroma .w {
   color: $surface0;
 }
+/* Error */
+.chroma .err {
+  /* not styled because Chroma uses it on too many things like JSX */
+}

--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -344,7 +344,8 @@ $lvl3: if($isDark, $base, $crust);
   &.green,
   &.red,
   &.teal,
-  &.purple {
+  &.purple,
+  &[class*="task-status-"] {
     color: $lvl1;
 
     &:hover {

--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -1,6 +1,7 @@
 @use "sass:color";
+@use "sass:string";
 
-// context-aware lighten: darkens if dark, lightens if light
+/* context-aware lighten: darkens if dark, lightens if light */
 @function ctx_lighten($color, $amount) {
   $multiplier: if($isDark, -1, 1);
   @return color.adjust($color, $lightness: $amount * $multiplier);
@@ -23,7 +24,8 @@ $lvl3: if($isDark, $base, $crust);
 
   --color-primary: #{$accent};
   --color-primary-contrast: #{$lvl1};
-  --color-primary-hover: #{ctx_lighten($accent, 5%)};
+  --color-primary-hover: #{ctx_lighten($accent, 3%)};
+  --color-primary-active: #{ctx_lighten($accent, 6%)};
 
   --color-primary-dark-1: #{ctx_lighten($accent, 3%)};
   --color-primary-dark-2: #{ctx_lighten($accent, 6%)};
@@ -51,36 +53,44 @@ $lvl3: if($isDark, $base, $crust);
   --color-primary-alpha-80: #{color.change($accent, $alpha: 0.8)};
   --color-primary-alpha-90: #{color.change($accent, $alpha: 0.9)};
 
-  --color-secondary: #{$surface1};
+  --color-secondary: #{$base};
+  --color-secondary-button: #{color.change($base, $alpha: 15%)};
+  --color-secondary-hover: #{color.change($base, $alpha: 30%)};
+  --color-secondary-active: #{color.change($base, $alpha: 45%)};
 
-  --color-secondary-dark-1: #{ctx_lighten($surface0, -3%)};
-  --color-secondary-dark-2: #{ctx_lighten($surface0, -6%)};
-  --color-secondary-dark-3: #{ctx_lighten($surface0, -9%)};
-  --color-secondary-dark-4: #{ctx_lighten($surface0, -12%)};
-  --color-secondary-dark-5: #{ctx_lighten($surface0, -15%)};
-  --color-secondary-dark-6: #{ctx_lighten($surface0, -18%)};
-  --color-secondary-dark-7: #{ctx_lighten($surface0, -21%)};
-  --color-secondary-dark-8: #{ctx_lighten($surface0, -24%)};
-  --color-secondary-dark-9: #{ctx_lighten($surface0, -27%)};
-  --color-secondary-dark-10: #{ctx_lighten($surface0, -30%)};
-  --color-secondary-dark-11: #{ctx_lighten($surface0, -33%)};
-  --color-secondary-dark-12: #{ctx_lighten($surface0, -36%)};
-  --color-secondary-dark-13: #{ctx_lighten($surface0, -39%)};
+  --color-secondary-dark-1: #{ctx_lighten($base, -3%)};
+  --color-secondary-dark-2: #{ctx_lighten($base, -6%)};
+  --color-secondary-dark-3: #{ctx_lighten($base, -9%)};
+  --color-secondary-dark-4: #{ctx_lighten($base, -12%)};
+  --color-secondary-dark-5: #{ctx_lighten($base, -15%)};
+  --color-secondary-dark-6: #{ctx_lighten($base, -18%)};
+  --color-secondary-dark-7: #{ctx_lighten($base, -21%)};
+  --color-secondary-dark-8: #{ctx_lighten($base, -24%)};
+  --color-secondary-dark-9: #{ctx_lighten($base, -27%)};
+  --color-secondary-dark-10: #{ctx_lighten($base, -30%)};
+  --color-secondary-dark-11: #{ctx_lighten($base, -33%)};
+  --color-secondary-dark-12: #{ctx_lighten($base, -36%)};
+  --color-secondary-dark-13: #{ctx_lighten($base, -39%)};
 
-  --color-secondary-light-1: #{ctx_lighten($surface0, 3%)};
-  --color-secondary-light-2: #{ctx_lighten($surface0, 6%)};
-  --color-secondary-light-3: #{ctx_lighten($surface0, 9%)};
-  --color-secondary-light-4: #{ctx_lighten($surface0, 12%)};
+  --color-secondary-light-1: #{ctx_lighten($base, 3%)};
+  --color-secondary-light-2: #{ctx_lighten($base, 6%)};
+  --color-secondary-light-3: #{ctx_lighten($base, 9%)};
+  --color-secondary-light-4: #{ctx_lighten($base, 12%)};
 
-  --color-secondary-alpha-10: #{color.change($surface0, $alpha: 0.1)};
-  --color-secondary-alpha-20: #{color.change($surface0, $alpha: 0.2)};
-  --color-secondary-alpha-30: #{color.change($surface0, $alpha: 0.3)};
-  --color-secondary-alpha-40: #{color.change($surface0, $alpha: 0.4)};
-  --color-secondary-alpha-50: #{color.change($surface0, $alpha: 0.5)};
-  --color-secondary-alpha-60: #{color.change($surface0, $alpha: 0.6)};
-  --color-secondary-alpha-70: #{color.change($surface0, $alpha: 0.7)};
-  --color-secondary-alpha-80: #{color.change($surface0, $alpha: 0.8)};
-  --color-secondary-alpha-90: #{color.change($surface0, $alpha: 0.9)};
+  --color-secondary-alpha-10: #{color.change($base, $alpha: 0.1)};
+  --color-secondary-alpha-20: #{color.change($base, $alpha: 0.2)};
+  --color-secondary-alpha-30: #{color.change($base, $alpha: 0.3)};
+  --color-secondary-alpha-40: #{color.change($base, $alpha: 0.4)};
+  --color-secondary-alpha-50: #{color.change($base, $alpha: 0.5)};
+  --color-secondary-alpha-60: #{color.change($base, $alpha: 0.6)};
+  --color-secondary-alpha-70: #{color.change($base, $alpha: 0.7)};
+  --color-secondary-alpha-80: #{color.change($base, $alpha: 0.8)};
+  --color-secondary-alpha-90: #{color.change($base, $alpha: 0.9)};
+
+  /* reactions */
+  --color-reaction-bg: #{color.change($text, $alpha: 0.07)};
+  --color-reaction-hover-bg: var(--color-primary-alpha-40);
+  --color-reaction-active-bg: var(--color-primary-alpha-30);
 
   /* colors */
   --color-red: #{$red};
@@ -96,6 +106,51 @@ $lvl3: if($isDark, $base, $crust);
   --color-brown: #{$flamingo};
   --color-grey: #{$overlay2};
   --color-black: #{if(isDark, $mantle, $text)};
+
+  @function ansibright($color) {
+    $l: color.channel($color, "lightness", $space: oklch);
+    $c: color.channel($color, "chroma", $space: oklch);
+    $h: color.channel($color, "hue", $space: oklch);
+
+    @if $isDark {
+      @return string.unquote(
+        "oklch(#{calc($l * 0.94)} #{calc($c + 0.08)} #{calc($h + 2deg)})"
+      );
+    } @else {
+      @return string.unquote(
+        "oklch(#{calc($l * 1.09)} #{$c} #{calc($h + 2deg)})"
+      );
+    }
+  }
+
+  /* ANSI colours */
+  --color-ansi-black: #{if(isDark, $surface1, $subtext1)};
+  --color-ansi-red: #{$red};
+  --color-ansi-green: #{$green};
+  --color-ansi-yellow: #{$yellow};
+  --color-ansi-blue: #{$blue};
+  --color-ansi-magenta: #{$pink};
+  --color-ansi-cyan: #{$teal};
+  --color-ansi-white: #{if(isDark, $subtext0, $surface2)};
+
+  --color-ansi-bright-black: #{if(isDark, $surface2, subtext0)};
+  --color-ansi-bright-red: #{ansibright($red)};
+  --color-ansi-bright-green: #{ansibright($green)};
+  --color-ansi-bright-yellow: #{ansibright($yellow)};
+  --color-ansi-bright-blue: #{ansibright($blue)};
+  --color-ansi-bright-magenta: #{ansibright($pink)};
+  --color-ansi-bright-cyan: #{ansibright($teal)};
+  --color-ansi-bright-white: #{if(isDark, $subtext1, $surface1)};
+
+  /* console colors */
+  --color-console-fg: #{$text};
+  --color-console-fg-subtle: #{$subtext0};
+  --color-console-bg: #{$mantle};
+  --color-console-border: #{$surface0};
+  --color-console-hover-bg: #{$surface1};
+  --color-console-active-bg: #{$surface2};
+  --color-console-menu-bg: #{$surface0};
+  --color-console-menu-border: #{$surface2};
 
   /* light variants - produced via Sass scale-color(color, $lightness: -10%) */
   --color-red-light: #{ctx_lighten($red, 10%)};
@@ -156,37 +211,38 @@ $lvl3: if($isDark, $base, $crust);
   --color-diff-added-row-border: #{color.change($green, $alpha: 0.07)};
   --color-diff-inactive: #{$overlay2};
   --color-error-border: #{$red};
-  --color-error-bg: #{$red};
-  --color-error-bg-active: #{ctx_lighten($red, 5%)};
-  --color-error-bg-hover: #{ctx_lighten($red, 10%)};
-  --color-error-text: #{$lvl1};
-  --color-success-border: #{ctx_lighten($green, 10%)};
-  --color-success-bg: #{$green};
-  --color-success-text: #{$lvl1};
-  --color-warning-border: #{ctx_lighten($yellow, 10%)};
-  --color-warning-bg: #{$yellow};
-  --color-warning-text: #{$lvl1};
-  --color-info-border: #{ctx_lighten($blue, 10%)};
-  --color-info-bg: #{$lvl1};
-  --color-info-text: #{$text};
-  --color-red-badge: #{ctx_lighten($red, 10%)};
-  --color-red-badge-bg: #{$lvl1};
-  --color-red-badge-hover-bg: #{ctx_lighten($red, 5%)};
+  --color-error-bg: #{color.change($red, $alpha: 15%)};
+  --color-error-bg-active: #{color.change($red, $alpha: 45%)};
+  --color-error-bg-hover: #{color.change($red, $alpha: 30%)};
+  --color-error-text: #{$red};
+  --color-success-border: #{$green};
+  --color-success-bg: #{color.change($green, $alpha: 15%)};
+  --color-success-text: #{$green};
+  --color-warning-border: #{$peach};
+  --color-warning-bg: #{color.change($peach, $alpha: 15%)};
+  --color-warning-text: #{$peach};
+  --color-info-border: #{$teal};
+  --color-info-bg: #{color.change($teal, $alpha: 15%)};
+  --color-info-text: #{$teal};
+  --color-red-badge: #{$red};
+  --color-red-badge-bg: #{color.change($red, $alpha: 15%)};
+  --color-red-badge-hover-bg: #{color.change($red, $alpha: 30%)};
   --color-green-badge: #{$green};
-  --color-green-badge-bg: #{$green};
-  --color-green-badge-hover-bg: #{ctx_lighten($green, 5%)};
+  --color-green-badge-bg: #{color.change($green, $alpha: 15%)};
+  --color-green-badge-hover-bg: #{color.change($green, $alpha: 30%)};
   --color-yellow-badge: #{$yellow};
-  --color-yellow-badge-bg: #{$lvl1};
-  --color-yellow-badge-hover-bg: #{ctx_lighten($yellow, 5%)};
+  --color-yellow-badge-bg: #{color.change($yellow, $alpha: 15%)};
+  --color-yellow-badge-hover-bg: #{color.change($yellow, $alpha: 30%)};
   --color-orange-badge: #{$peach};
-  --color-orange-badge-bg: #{$lvl1};
-  --color-orange-badge-hover-bg: #{ctx_lighten($peach, 5%)};
+  --color-orange-badge-bg: #{color.change($peach, $alpha: 15%)};
+  --color-orange-badge-hover-bg: #{color.change($peach, $alpha: 30%)};
   --color-git: #{$peach};
-  --color-highlight-bg: #{color.change($yellow, $alpha: 0.15)};
+  --color-highlight-fg: #{$peach};
+  --color-highlight-bg: #{color.change($yellow, $alpha: 15%)};
 
   /* target-based colors */
   --color-body: #{$lvl1};
-  --color-box-header: #{$lvl2};
+  --color-box-header: #{$lvl3};
   --color-box-body: #{$lvl2};
   --color-box-body-highlight: #{$surface0};
   --color-text-dark: #{$subtext0};
@@ -196,6 +252,7 @@ $lvl3: if($isDark, $base, $crust);
   --color-text-light-2: #{$subtext1};
   --color-text-light-3: #{$subtext1};
   --color-footer: #{$lvl2};
+  --color-footer-text: #{$subtext0};
   --color-timeline: #{$surface0};
   --color-input-text: #{$text};
   --color-input-background: #{$surface0};
@@ -203,7 +260,10 @@ $lvl3: if($isDark, $base, $crust);
   --color-input-border: #{$surface1};
   --color-input-border-hover: #{$surface2};
   --color-nav-bg: #{$lvl2};
-  --color-nav-hover-bg: var(--color-hover);
+  --color-nav-hover-bg: #{ctx_lighten($lvl2, 3%)};
+  --color-nav-active-bg: #{ctx_lighten($lvl2, 6%)};
+  --color-nav-text: #{$text};
+  --color-secondary-nav-bg: #{$lvl1};
   --color-navbar: #{$lvl2};
   --color-navbar-transparent: #{color.change($lvl1, $alpha: 0)};
   --color-light: #{color.change($surface2, $alpha: 0.3)};
@@ -213,20 +273,18 @@ $lvl3: if($isDark, $base, $crust);
     0,
     calc(40 / 255 * 222 / 255 / var(--opacity-disabled))
   );
-  --color-light-border: #{$surface2};
-  --color-hover: #{color.change($overlay0, $alpha: 0.2)};
-  --color-active: #{color.change($text, $alpha: 0.1)};
-  --color-menu: #{$surface0};
+  --color-light-border: #{$surface1};
+  --color-hover: #{ctx_lighten($surface0, -3%)};
+  --color-active: #{$surface1};
+  --color-menu: #{$base};
   --color-card: #{$surface0};
   --color-markup-table-row: #{color.change($text, $alpha: 0.02)};
   --color-markup-code-block: #{color.change($text, $alpha: 0.05)};
   --color-markup-code-inline: #{$surface0};
   --color-button: #{$surface0};
-  --color-code-bg: #{$base};
+  --color-code-bg: #{$lvl2};
   --color-code-sidebar-bg: #{$surface0};
   --color-shadow: #{color.change($lvl1, $alpha: 0.1)};
-  --color-tooltip-bg: #{$surface0};
-  --color-tooltip-text: var(--color-text);
   --color-secondary-bg: #{$surface0};
   --color-text-focus: #{$text};
   --color-expand-button: #{$surface2};
@@ -236,17 +294,22 @@ $lvl3: if($isDark, $base, $crust);
   /* gitea source code: */
   /* should ideally be --color-text-dark, see go-gitea/gitea#15651 */
   --color-caret: var(--color-text);
-  --color-reaction-bg: #{color.change($text, $alpha: 0.07)};
-  --color-reaction-active-bg: var(--color-primary-alpha-40);
   --color-header-wrapper: #{$lvl2};
   --color-header-wrapper-transparent: #{color.change($lvl2, $alpha: 0)};
-  --color-label-text: #{$crust};
-  --color-label-bg: #{$accent};
-  --color-label-hover-bg: #{ctx_lighten($accent, 6%)};
-  --color-label-active-bg: #{ctx_lighten($accent, 3%)};
+  --color-label-text: #{$text};
+  --color-label-bg: #{$surface0};
+  --color-label-hover-bg: #{ctx_lighten($surface0, 3%)};
+  --color-label-active-bg: #{ctx_lighten($surface0, 6%)};
   --color-accent: var(--color-primary-light-1);
   --color-small-accent: var(--color-primary-light-5);
   --color-active-line: #{$surface1};
+
+  /* tooltips */
+  --color-overlay-backdrop: #{color.change($crust, $alpha: 60%)};
+  --checkerboard-color-1: #{$surface0};
+  --checkerboard-color-2: #{$surface1};
+  --color-tooltip-text: #{$text}; /* tippy box text (fixed page info) */
+  --color-tooltip-bg: #{$surface0}; /* tippy box bg (popup) */
 }
 
 @if $isDark {
@@ -280,8 +343,10 @@ $lvl3: if($isDark, $base, $crust);
   &.primary,
   &.green,
   &.red,
-  &.teal {
+  &.teal,
+  &.purple {
     color: $lvl1;
+
     &:hover {
       color: $lvl3;
     }
@@ -292,59 +357,70 @@ $lvl3: if($isDark, $base, $crust);
   background-color: $lvl3;
 }
 
-// link color for signed commits
+/* link color for signed commits */
 .ui.commit-header-row .svg.gitea-lock ~ a {
   color: $lvl1;
 }
 
-// error message headers weirdly don't seem to be using --color-error-text
+/* error message headers weirdly don't seem to be using --color-error-text */
 .ui.negative.message .header {
   color: var(--color-error-text);
 }
 
-// most recent commit hover when signed
+/* most recent commit hover when signed */
 .ui.sha.isSigned.isVerified {
   .shortsha {
     color: $lvl1;
   }
+
   svg.gitea-lock {
     fill: $lvl1;
   }
 }
 
-// modal text color for the "Remove GPG Key" modal
+/* modal text color for the "Remove GPG Key" modal */
 .ui.basic.modal,
 .ui.basic.modal > .header,
 .ui.inverted.button {
   color: $text !important;
 }
 
+:is(form input[type="checkbox"]):checked::after {
+  background: var(--color-primary-contrast) !important;
+}
+
 #repo-topics,
-// repository topics when in edit mode
+  /* repository topics when in edit mode */
 #topic_edit > .ui.selection.dropdown {
   color: var(--color-label-text) !important;
 }
 
-// repository topics edit button
+/* repository topics edit button */
 #manage_topic {
   color: var(--color-text-light-2) !important;
 }
 
-// admonitions are using *-text variables for border/text colour
-// can't change values of the *-text variables without breaking readability on accented backgrounds
+/*
+ * admonitions are using *-text variables for border/text colour
+ * can't change values of the *-text variables without breaking
+ * readability on accented backgrounds
+ */
 blockquote {
   &.attention-tip {
     border-left-color: var(--color-success-bg);
   }
+
   &.attention-warning {
     border-left-color: var(--color-warning-bg);
   }
 }
+
 svg,
 strong {
   &.attention-tip {
     color: var(--color-success-bg);
   }
+
   &.attention-warning {
     color: var(--color-warning-bg);
   }

--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -287,7 +287,7 @@ $lvl3: if($isDark, $base, $crust);
   --color-shadow: #{color.change($lvl1, $alpha: 0.1)};
   --color-secondary-bg: #{$surface0};
   --color-text-focus: #{$text};
-  --color-expand-button: #{$surface2};
+  --color-expand-button: #{$surface1};
   --color-placeholder-text: #{$subtext0};
   --color-editor-line-highlight: var(--color-primary-light-5);
   --color-project-board-bg: var(--color-secondary-light-2);

--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -353,6 +353,13 @@ $lvl3: if($isDark, $base, $crust);
   }
 }
 
+.ui.table {
+  > tr > td,
+  > tbody > tr > td {
+    border-top: 1px solid var(--color-secondary-dark-1);
+  }
+}
+
 .ui.basic.modal {
   background-color: $lvl3;
 }


### PR DESCRIPTION
I used #82, #87 and #91 as a base and adapted it to be closer to the default "Forgejo Dark" theme. Also fixed some minor things.

It looks correct everywhere where I could check. But I only tested one theme variant (listed below).

Here is how it looks like with "Catppuccin Mocha Lavender":

<img width="4632" height="2562" alt="image" src="https://github.com/user-attachments/assets/c7f3b8af-546d-4b4b-be7e-595fab8f1e2c" />

